### PR TITLE
In beta we only support "CVS-Performance"

### DIFF
--- a/get-started/requirements.adoc
+++ b/get-started/requirements.adoc
@@ -20,7 +20,7 @@ On-prem Kubernetes clusters and clusters running in other cloud providers are no
 
 * Clusters must be running in a healthy state.
 
-* Clusters must be in a https://cloud.netapp.com/cloud-volumes-global-regions#cvsGc[Google Cloud region that supports the Cloud Volumes Service's "CVS-Performance" service type for Google Cloud^].
+* Clusters must be in a https://cloud.netapp.com/cloud-volumes-global-regions#cvsGc[Google Cloud region that support the "CVS-Performance" service type for Cloud Volumes Service^].
 
 * A cluster must be running Kubernetes version 1.17 or later.
 

--- a/get-started/requirements.adoc
+++ b/get-started/requirements.adoc
@@ -20,7 +20,7 @@ On-prem Kubernetes clusters and clusters running in other cloud providers are no
 
 * Clusters must be running in a healthy state.
 
-* Clusters must be in a https://cloud.netapp.com/cloud-volumes-global-regions#cvsGc[Google Cloud region that support the "CVS-Performance" service type for Cloud Volumes Service^].
+* Clusters must be in a https://cloud.netapp.com/cloud-volumes-global-regions#cvsGc[Google Cloud region that supports the "CVS-Performance" service type for Cloud Volumes Service^].
 
 * A cluster must be running Kubernetes version 1.17 or later.
 

--- a/get-started/requirements.adoc
+++ b/get-started/requirements.adoc
@@ -18,7 +18,9 @@ Get started by verifying support for your Kubernetes clusters, apps, and web bro
 +
 On-prem Kubernetes clusters and clusters running in other cloud providers are not supported at this time.
 
-* Clusters must be running in a healthy state, in a https://cloud.netapp.com/cloud-volumes-global-regions#cvsGc[Google Cloud region that supports Cloud Volumes Service for Google Cloud^].
+* Clusters must be running in a healthy state.
+
+* Clusters must be in a https://cloud.netapp.com/cloud-volumes-global-regions#cvsGc[Google Cloud region that supports the Cloud Volumes Service's "CVS-Performance" service type for Google Cloud^].
 
 * A cluster must be running Kubernetes version 1.17 or later.
 


### PR DESCRIPTION
Suggest informing beta users of this additional restriction, so they don't create GKE clusters in regions that we don't yet support.